### PR TITLE
Fix backend auth headers

### DIFF
--- a/ai-agent-network/tools/backend_bridge.py
+++ b/ai-agent-network/tools/backend_bridge.py
@@ -19,11 +19,6 @@ BACKEND_SERVICE_ID = os.getenv("BACKEND_SERVICE_ID")
 AI_AGENT_ID = os.getenv("AI_AGENT_ID")
 AI_AGENT_VERSION = os.getenv("AI_AGENT_VERSION")
 
-def headers() -> dict:
-    return {
-        "Request-Secret": os.getenv("BACKEND_SECRET"),
-        "Content-Type": "application/json"
-    }
 
 
 def get_backend_token() -> str:
@@ -51,6 +46,7 @@ def get_backend_token() -> str:
 def headers() -> dict:
     return {
         "Authorization": f"Bearer {get_backend_token()}",
+        "Request-Secret": BACKEND_SECRET,
         "Content-Type": "application/json"
     }
 

--- a/ai-db-backend/src/modules/query/routes.ts
+++ b/ai-db-backend/src/modules/query/routes.ts
@@ -1,7 +1,7 @@
 // src/modules/query/routes.ts
 
 import { Router } from "express";
-import { verifyTokenMiddleware } from "../auth/middleware/verification.middleware";
+import { verifyTokenMiddleware, verifyBackendRequest } from "../auth/middleware/verification.middleware";
 import { requireRole } from "../auth/middleware/rbac.middleware";
 import * as ws from "ws";
 
@@ -62,9 +62,9 @@ router.get("/multi/history", verifyTokenMiddleware, getMultiDbQueryHistory);
 // AI Agent Bridge Routes - Specifically for AI Agent Network integration
 // ==============================
 // These routes match the ones expected by the AI agent network in utils/backend_bridge.py
-router.post("/query/execute", verifyTokenMiddleware, executeQueryForAIAgent);
-router.post("/schema/fetch", verifyTokenMiddleware, fetchSchemaForAIAgent);
-router.post("/conversation/store", verifyTokenMiddleware, storeConversationContext);
+router.post("/query/execute", verifyBackendRequest, executeQueryForAIAgent);
+router.post("/schema/fetch", verifyBackendRequest, fetchSchemaForAIAgent);
+router.post("/conversation/store", verifyBackendRequest, storeConversationContext);
 
 // Export the router
 export default router;


### PR DESCRIPTION
## Summary
- patch backend routes to use verifyBackendRequest for agent network
- clean backend_bridge headers for Request-Secret token

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json` *(fails to find node definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68489ea2f27483319a43e1ee5b473f64